### PR TITLE
fix: remove order details after payment cancel

### DIFF
--- a/src/pages/Checkout/PaymentDetails.jsx
+++ b/src/pages/Checkout/PaymentDetails.jsx
@@ -109,6 +109,13 @@ const PaymentDetails = ({
         theme: {
           color: "#121212",
         },
+        modal: {
+          ondismiss: function () {
+            localStorage.removeItem("orderDetails");
+            setIsProcessing(false);
+            toast.error("Payment Cancelled");
+          },
+        },
       };
       const razor = new window.Razorpay(options);
       razor.open();


### PR DESCRIPTION
```jsx
modal: {
          ondismiss: function () {
            localStorage.removeItem("orderDetails");
            setIsProcessing(false);
            toast.error("Payment Cancelled");
          },
        },
```